### PR TITLE
feat: fixes audit H2 & M3

### DIFF
--- a/test/LockedRevenueDistributionToken/LockedRevenueDistributionTokenBaseTest.t.sol
+++ b/test/LockedRevenueDistributionToken/LockedRevenueDistributionTokenBaseTest.t.sol
@@ -36,7 +36,7 @@ abstract contract LockedRevenueDistributionTokenBaseTest is Test {
 
         asset.approve(address(vault), assets_);
         vault.deposit(assets_, depositor_);
-        assertEq(asset.balanceOf(alice), balanceBefore_);
+        assertEq(asset.balanceOf(depositor_), balanceBefore_);
     }
 
     function _addAndVestRewards(uint256 assets_) internal {


### PR DESCRIPTION
When a staker withdraws from the vault this will immediately change the assets and share ratio because the amount of assets burned for shares is not equivalent to the current rate, opening up a front-running opportunity wherein an attacker could monitor the blockchain for withdraw events and deposit immediately before, giving themselves a more favourable amount of shares.

Due to the lockup timem enforced by LRDT this will likely not be catastrophic. An attacker would be able to receive more favourable deposit conditions but would still be subject to the lockup time or instant withdrawal fee, making it unlikely that this front run could result in an immediate arbitrage via withdrawal.

It is preferable to make sure that all rewards are subject a vesting cycle to prevent timing attacks and therefore all reward types will be issued via `updateVestingSchedule()`.