### PR TITLE
feat: fixes audit M1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,8 @@ CHAIN_ID=1
 PRECISION=`echo '2^96 - 1' | bc`
 INSTANT_WITHDRAWAL_FEE=15
 LOCK_TIME_WEEKS=26
+INITIAL_SEED=1000000000000000000
+VERIFY=1
 
 .PHONY: myth
 myth:
@@ -25,22 +27,33 @@ deploy-mockerc20:
 		--chain $(CHAIN_ID) \
 		--constructor-args "$(NAME)" "$(SYMBOL)"
 
+.PHONY: mint-mockerc20
+mint-mockerc20:
+	@cast send $(ASSET) "mint(address,uint256)" $(FROM) $(INITIAL_SEED) \
+		--rpc-url $(RPC_URL) \
+		--from $(FROM) \
+		--private-key $(PRIVATE_KEY)
+
 .PHONY: deploy-lrdt
 deploy-lrdt:
+	@cast send $(ASSET) "approve(address,uint256)" $$(cast compute-address $(FROM) --nonce $$(($$(cast nonce $(FROM)) + 1)) | sed 's/Computed Address: //') "$(INITIAL_SEED)" \
+		--private-key $(PRIVATE_KEY)
 	@forge create src/LockedRevenueDistributionToken.sol:LockedRevenueDistributionToken \
 		--rpc-url $(RPC_URL) \
 		--from $(FROM) \
 		--private-key $(PRIVATE_KEY) \
 		--chain $(CHAIN_ID) \
-		--verify \
-		--constructor-args "$(NAME)" "$(SYMBOL)" "$(OWNER)" "$(ASSET)" $(PRECISION) $(INSTANT_WITHDRAWAL_FEE) $$(($(LOCK_TIME_WEEKS) * 7 * 24 * 60 * 60))
+		$(if $(VERIFY == 1),--verify) \
+		--constructor-args "$(NAME)" "$(SYMBOL)" "$(OWNER)" "$(ASSET)" $(PRECISION) $(INSTANT_WITHDRAWAL_FEE) $$(($(LOCK_TIME_WEEKS) * 7 * 24 * 60 * 60)) $(INITIAL_SEED)
 
 .PHONY: deploy-glrdt
 deploy-glrdt:
+	@cast send $(ASSET) "approve(address,uint256)" $$(cast compute-address $(FROM) --nonce $$(($$(cast nonce $(FROM)) + 1)) | sed 's/Computed Address: //') "$(INITIAL_SEED)" \
+		--private-key $(PRIVATE_KEY)
 	@forge create src/GovernanceLockedRevenueDistributionToken.sol:GovernanceLockedRevenueDistributionToken \
 		--rpc-url $(RPC_URL) \
 		--from $(FROM) \
 		--private-key $(PRIVATE_KEY) \
 		--chain $(CHAIN_ID) \
-		--verify \
-		--constructor-args "$(NAME)" "$(SYMBOL)" "$(OWNER)" "$(ASSET)" $(PRECISION) $(INSTANT_WITHDRAWAL_FEE) $$(($(LOCK_TIME_WEEKS) * 7 * 24 * 60 * 60))
+		$(if $(VERIFY == 1),--verify) \
+		--constructor-args "$(NAME)" "$(SYMBOL)" "$(OWNER)" "$(ASSET)" $(PRECISION) $(INSTANT_WITHDRAWAL_FEE) $$(($(LOCK_TIME_WEEKS) * 7 * 24 * 60 * 60)) $(INITIAL_SEED)

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ The following defaults are set and can be overridden by passing parameters to th
 - PRECISION=`type(uint96).max`=`2^96 - 1`
 - INSTANT_WITHDRAWAL_FEE=15
 - LOCK_TIME_WEEKS=26
+- INITIAL_SEED=`1 ether`=1000000000000000000
 
 FROM & PRIVATE_KEY have been set to Anvil account 0 defaults. Ensure to provide a new secured key for production deployments.
 
@@ -94,6 +95,20 @@ Deployment & verification can be ran with:
 ```
 ETHERSCAN_API_KEY=<key> make deploy-glrdt NAME="xASSET" RPC_URL="<url>" FROM="<address>" PRIVATE_KEY="<key>" SYMBOL="xASSET" OWNER="<address>" ASSET="<address>" INSTANT_WITHDRAWAL_FEE="<0-99,integer>" LOCK_TIME_WEEKS"<integer>"
 ```
+
+Deployments can be tested locally using a mock ERC20 contract:
+
+```
+make deploy-mockerc20
+make mint-mockerc20 ASSET="<address>"
+make deploy-glrdt NAME="xASSET" SYMBOL="xASSET" OWNER="<address>" ASSET="<address>" VERIFY=0
+```
+
+#### Setting the INITIAL_SEED
+
+When the vault is first deployed and there are a low number of shares issued it is possible for an adversary to perform a [donation attack](https://github.com/OpenZeppelin/openzeppelin-contracts/issues/3706) wherein they transfer rewards directly to the contract that creates a skew of precision between the assets within the contract and the shares issued. There are a number of protection mechanisms to prevent this and this is resolved in LRDT by burning a number of shares at the time of deployment to ensure that the precision between shares and assets cannot differ too greatly. By default this has been set to `1 ether` and this is required to be available to the constructor at the time of deployment.
+
+This means that the contract address must be calculated in advance so that an approval can be set on the asset to be initialized. Within the deployment scripts this is handled using `cast compute-address`.
 
 ### Static Analysis
 

--- a/src/GovernanceLockedRevenueDistributionToken.sol
+++ b/src/GovernanceLockedRevenueDistributionToken.sol
@@ -53,9 +53,10 @@ contract GovernanceLockedRevenueDistributionToken is
         address asset_,
         uint256 precision_,
         uint256 instantWithdrawalFee_,
-        uint256 lockTime_
+        uint256 lockTime_,
+        uint256 initialSeed_
     )
-        LockedRevenueDistributionToken(name_, symbol_, owner_, asset_, precision_, instantWithdrawalFee_, lockTime_, 0)
+        LockedRevenueDistributionToken(name_, symbol_, owner_, asset_, precision_, instantWithdrawalFee_, lockTime_, initialSeed_)
     {}
 
     /*░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░

--- a/src/GovernanceLockedRevenueDistributionToken.sol
+++ b/src/GovernanceLockedRevenueDistributionToken.sol
@@ -55,7 +55,7 @@ contract GovernanceLockedRevenueDistributionToken is
         uint256 instantWithdrawalFee_,
         uint256 lockTime_
     )
-        LockedRevenueDistributionToken(name_, symbol_, owner_, asset_, precision_, instantWithdrawalFee_, lockTime_)
+        LockedRevenueDistributionToken(name_, symbol_, owner_, asset_, precision_, instantWithdrawalFee_, lockTime_, 0)
     {}
 
     /*░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░

--- a/test/GovernanceLockedRevenueDistributionToken/GovernanceLockedRevenueDistributionTokenBaseTest.t.sol
+++ b/test/GovernanceLockedRevenueDistributionToken/GovernanceLockedRevenueDistributionTokenBaseTest.t.sol
@@ -41,7 +41,8 @@ abstract contract GovernanceLockedRevenueDistributionTokenBaseTest is Test {
             address(asset),
             type(uint112).max,
             10,
-            26 weeks
+            26 weeks,
+            0
         );
         vm.warp(start); // Warp to non-zero timestamp
     }

--- a/test/LockedRevenueDistributionToken/InitialDeposit.t.sol
+++ b/test/LockedRevenueDistributionToken/InitialDeposit.t.sol
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity ^0.8.7;
+
+import "./LockedRevenueDistributionTokenBaseTest.t.sol";
+
+contract InitialDepositTest is LockedRevenueDistributionTokenBaseTest {
+    uint256 constant initialSeed = 1 ether;
+
+    function testCannotDeployWithoutApproval() public {
+        vm.expectRevert("LRDT:C:TRANSFER_FROM");
+        _deploy();
+    }
+
+    function testCannotDeployInsufficientBalance() public {
+        asset.approve(_getAddress(), initialSeed);
+        vm.expectRevert("LRDT:C:TRANSFER_FROM");
+        _deploy();
+    }
+
+    function testDeployWithApproval() public {
+        address predictedAddress_ = _getAddress();
+
+        asset.mint(address(this), initialSeed);
+        asset.approve(predictedAddress_, initialSeed);
+
+        LockedRevenueDistributionToken vault = _deploy();
+        assertEq(address(vault), predictedAddress_);
+    }
+
+    function testDeployHasBurnedShares() public {
+        asset.mint(address(this), initialSeed);
+        asset.approve(_getAddress(), initialSeed);
+
+        LockedRevenueDistributionToken vault = _deploy();
+        assertEq(vault.balanceOf(address(0)), initialSeed);
+        assertEq(vault.balanceOfAssets(address(0)), initialSeed);
+        assertEq(asset.balanceOf(address(vault)), initialSeed);
+        assertEq(vault.freeAssets(), initialSeed);
+        assertEq(vault.totalAssets(), initialSeed);
+    }
+
+    function testDonationAttack() public {
+        asset.mint(address(this), initialSeed);
+        asset.approve(_getAddress(), initialSeed);
+
+        // The current `vault` in use has been initialized with an initialSeed value of 0, meaning no shares have been
+        // burned as part of the constructor. These burned shares are necessary to prevent donation attacks.
+        //
+        // We first demonstrate these attacks on the contract using the unprotected vault with dust remaining.
+        // Alice deposts 1 ether and withdraws all but a dust amount.
+        _setUpDepositor(alice, 1 ether);
+        uint256 allButDust = 1 ether - 1;
+        vault.createWithdrawalRequest(allButDust);
+        vm.warp(block.timestamp + 26 weeks);
+        vault.executeWithdrawalRequest(0);
+        vm.stopPrank();
+        assertEq(vault.previewDeposit(1 ether), 1 ether);
+
+        // Another user, Bob, can perform a donation to the contract introducing a large skew in precision between the
+        // number of shares remaining (1) and the assets donated (14 ether). This 14 ether deposit vastly increases the
+        // rate of shares:assets making further deposits unfeasible.
+        asset.mint(bob, 14 ether + 1);
+        // Bob performs the donation. With a 1 day wait, it will require 14 times the capital of the other user to
+        // issue 0 shares. This is because the vesting schedule follows a linear issuance mechanism over the course of
+        // 14 days.
+        vm.startPrank(bob);
+        asset.transfer(address(vault), 14 ether + 1);
+        vault.updateVestingSchedule();
+        vm.warp(block.timestamp + 1 days);
+        vm.stopPrank();
+        assertEq(vault.previewDeposit(1 ether), 0);
+
+        // To demonstrate the protection we now demonstrate the deployment of a new vault that requires burning of 1
+        // ether worth of shares within the constructor.
+        asset.mint(address(this), initialSeed);
+        asset.approve(_getAddress(), initialSeed);
+        vault = _deploy();
+
+        // Alice is then setup within the new vault and performs the same withdrawal.
+        _setUpDepositor(alice, 1 ether);
+        vault.createWithdrawalRequest(allButDust);
+        vm.warp(block.timestamp + 26 weeks);
+        vault.executeWithdrawalRequest(0);
+        vm.stopPrank();
+        assertEq(vault.previewDeposit(1 ether), 1 ether);
+
+        // However now Bob is unable to mark down further deposits to 0 due to the 1 ether worth of burned shares that
+        // still remains on the zero address.
+        assertEq(vault.balanceOf(address(0)), initialSeed);
+        assertEq(asset.balanceOf(address(vault)), initialSeed + 1);
+        asset.mint(bob, 14 ether + 1);
+        vm.startPrank(bob);
+        asset.transfer(address(vault), 14 ether + 1);
+        vault.updateVestingSchedule();
+        vm.warp(block.timestamp + 1 days);
+        vm.stopPrank();
+        assertEq(vault.previewDeposit(1 ether), 0.5 ether);
+    }
+
+    function _getBytecode() internal view returns (bytes memory) {
+        bytes memory bytecode = type(LockedRevenueDistributionToken).creationCode;
+
+        return abi.encodePacked(
+            bytecode,
+            abi.encode(
+                "xASSET",
+                "xASSET",
+                address(this),
+                address(asset),
+                type(uint96).max,
+                instantWithdrawalFee,
+                26 weeks,
+                initialSeed
+            )
+        );
+    }
+
+    function _getAddress() internal view returns (address) {
+        return address(
+            uint160(
+                uint256(
+                    keccak256(abi.encodePacked(bytes1(0xff), address(this), bytes32("salt"), keccak256(_getBytecode())))
+                )
+            )
+        );
+    }
+
+    function _deploy() internal returns (LockedRevenueDistributionToken) {
+        return new LockedRevenueDistributionToken{salt: bytes32("salt")}(
+            "xASSET",
+            "xASSET",
+            address(this),
+            address(asset),
+            type(uint96).max,
+            instantWithdrawalFee,
+            26 weeks,
+            initialSeed
+        );
+    }
+}

--- a/test/LockedRevenueDistributionToken/LockedRevenueDistributionTokenBaseTest.t.sol
+++ b/test/LockedRevenueDistributionToken/LockedRevenueDistributionTokenBaseTest.t.sol
@@ -22,7 +22,8 @@ abstract contract LockedRevenueDistributionTokenBaseTest is Test {
             address(asset),
             type(uint96).max,
             instantWithdrawalFee,
-            26 weeks
+            26 weeks,
+            0
         );
         vm.warp(start); // Warp to non-zero timestamp
     }


### PR DESCRIPTION
When the vault is first deployed and there are a low number of shares issued it is possible for an adversary to perform a donation attack wherein they transfer rewards directly to the contract create a skew of precision between the assets within the contract and the shares issued.

There are a number of protection mechanisms to prevent this and this is resolved in LRDT by burning a number of shares at the time of deployment to ensure that the precision between shares and assets cannot differ too greatly. By default this has been set to `1 ether` and this is required to be available to the constructor at the time of deployment.