### PR TITLE
fix: carry over remaining vesting time

### DIFF
--- a/src/LockedRevenueDistributionToken.sol
+++ b/src/LockedRevenueDistributionToken.sol
@@ -183,12 +183,18 @@ contract LockedRevenueDistributionToken is ILockedRevenueDistributionToken, Reve
         // Update "y-intercept" to reflect current available asset.
         freeAssets_ = (freeAssets = totalAssets());
 
+        // Carry over remaining time.
+        uint256 vestingTime_ = VESTING_PERIOD;
+        if (vestingPeriodFinish > block.timestamp) {
+            vestingTime_ = VESTING_PERIOD + (vestingPeriodFinish - block.timestamp);
+        }
+
         // Calculate slope.
         issuanceRate_ =
-            (issuanceRate = ((ERC20(asset).balanceOf(address(this)) - freeAssets_) * precision) / VESTING_PERIOD);
+            (issuanceRate = ((ERC20(asset).balanceOf(address(this)) - freeAssets_) * precision) / vestingTime_);
 
         // Update timestamp and period finish.
-        vestingPeriodFinish = (lastUpdated = block.timestamp) + VESTING_PERIOD;
+        vestingPeriodFinish = (lastUpdated = block.timestamp) + vestingTime_;
 
         emit IssuanceParamsUpdated(freeAssets_, issuanceRate_);
         emit VestingScheduleUpdated(msg.sender, vestingPeriodFinish);


### PR DESCRIPTION
The ambition of the public `updateVestingSchedule` was both for this to be autonomous without admin roles as well as ensuring that a vesting cycle will execute consistently on the same day and time of the week, every two weeks.

Therefore if the first vesting period starts at 12pm Monday then we should expect the next one to finish at this time. The purpose of this is to allow for cron-like automation where the vesting period can be updated on a regular schedule and the cyles become predictable and cosistent for reporting.

Prior to this change the vestingPeriodFinish would drift earlier depending how long this was called before the finish time.