### PR TITLE
feat: fixes audit M6

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ GovernanceLockedRevenueDistributionToken (GLRDT) extends LockedRevenueDistributi
 
 - [ERC20](https://github.com/maple-labs/erc20/tree/v1.0.0) implements the ERC-20 token standard and transfers.
   - [RevenueDistributionToken](https://github.com/maple-labs/revenue-distribution-token/tree/v1.0.1) implements reward distributions and the ERC-4626 vault standard.
-    - [LockedRevenueDistributionToken](src/LockedRevenueDistributionToken.sol) implements time-restricted and fee-restricted withdrawals.
+    - [LockedRevenueDistributionToken](src/LockedRevenueDistributionToken.sol) implements time-restricted and fee-restricted withdrawals, and [ERC5143](https://eips.ethereum.org/EIPS/eip-5143) slippage protection.
       - [GovernanceLockedRevenueDistributionToken](src/GovernanceLockedRevenueDistributionToken.sol) implements Compound-compatible governance voting.
 
 It is possible to use LRDT without the governance properties of GLRDT by inheriting or deploying it directly.
@@ -32,7 +32,7 @@ LRDT has been designed to be a foundation for governance tokens, which often req
 1. Time-based 'Standard' withdrawals, not subject to a fee.
 2. Fee-based 'Instant' withdrawals, available instantly.
 
-This results in a system wherein participants must be subject to withdrawal conditions thereby demonstrating a longer term horizon and commitment to the protocol.
+This results in a system wherein participants must be subject to withdrawal conditions thereby demonstrating a longer term horizon and commitment to the protocol. Slippage protection has been added by implementing the [ERC5143](https://eips.ethereum.org/EIPS/eip-5143) standard.
 
 ![Deposit & Withdrawal Flow](docs/images/deposit-withdrawal-flow.jpg)
 

--- a/lib/revenue-distribution-token/README.md
+++ b/lib/revenue-distribution-token/README.md
@@ -6,4 +6,6 @@ Based on [Maple Lab's RevenueDistributionToken v1.0.1](https://github.com/maple-
 
 See diff using `make diff`.
 
-Unchanged aside from import paths.
+### 1. Public `deposit`, `mint`
+
+To support reuse of the slippage-protected ERC5143 deposit and mint functions implemented in LRDT, the deposit and mint functions of RDT have been made public.

--- a/lib/revenue-distribution-token/contracts/RevenueDistributionToken.sol
+++ b/lib/revenue-distribution-token/contracts/RevenueDistributionToken.sol
@@ -96,7 +96,7 @@ contract RevenueDistributionToken is IRevenueDistributionToken, ERC20 {
     /*** Staker Functions ***/
     /************************/
 
-    function deposit(uint256 assets_, address receiver_) external virtual override nonReentrant returns (uint256 shares_) {
+    function deposit(uint256 assets_, address receiver_) public virtual override nonReentrant returns (uint256 shares_) {
         _mint(shares_ = previewDeposit(assets_), assets_, receiver_, msg.sender);
     }
 
@@ -114,7 +114,7 @@ contract RevenueDistributionToken is IRevenueDistributionToken, ERC20 {
         _mint(shares_ = previewDeposit(assets_), assets_, receiver_, msg.sender);
     }
 
-    function mint(uint256 shares_, address receiver_) external virtual override nonReentrant returns (uint256 assets_) {
+    function mint(uint256 shares_, address receiver_) public virtual override nonReentrant returns (uint256 assets_) {
         _mint(shares_, assets_ = previewMint(shares_), receiver_, msg.sender);
     }
 

--- a/src/LockedRevenueDistributionToken.sol
+++ b/src/LockedRevenueDistributionToken.sol
@@ -232,11 +232,39 @@ contract LockedRevenueDistributionToken is ILockedRevenueDistributionToken, Reve
     }
 
     /**
+     * @inheritdoc ILockedRevenueDistributionToken
+     * @dev Reentrancy modifier provided within the internal function call.
+     */
+    function deposit(uint256 assets_, address receiver_, uint256 minShares_)
+        external
+        virtual
+        override
+        returns (uint256 shares_)
+    {
+        shares_ = deposit(assets_, receiver_);
+        require(shares_ >= minShares_, "LRDT:D:SLIPPAGE_PROTECTION");
+    }
+
+    /**
+     * @inheritdoc ILockedRevenueDistributionToken
+     * @dev Reentrancy modifier provided within the internal function call.
+     */
+    function mint(uint256 shares_, address receiver_, uint256 maxAssets_)
+        external
+        virtual
+        override
+        returns (uint256 assets_)
+    {
+        assets_ = mint(shares_, receiver_);
+        require(assets_ <= maxAssets_, "LRDT:M:SLIPPAGE_PROTECTION");
+    }
+
+    /**
      * @inheritdoc RevenueDistributionToken
      * @dev Will check for withdrawal fee exemption present on owner.
      */
     function redeem(uint256 shares_, address receiver_, address owner_)
-        external
+        public
         virtual
         override
         nonReentrant
@@ -252,11 +280,25 @@ contract LockedRevenueDistributionToken is ILockedRevenueDistributionToken, Reve
     }
 
     /**
+     * @inheritdoc ILockedRevenueDistributionToken
+     * @dev Reentrancy modifier provided within the internal function call.
+     */
+    function redeem(uint256 shares_, address receiver_, address owner_, uint256 minAssets_)
+        external
+        virtual
+        override
+        returns (uint256 assets_)
+    {
+        assets_ = redeem(shares_, receiver_, owner_);
+        require(assets_ >= minAssets_, "LRDT:R:SLIPPAGE_PROTECTION");
+    }
+
+    /**
      * @inheritdoc RevenueDistributionToken
      * @dev Will check for withdrawal fee exemption present on owner.
      */
     function withdraw(uint256 assets_, address receiver_, address owner_)
-        external
+        public
         virtual
         override
         nonReentrant
@@ -269,6 +311,20 @@ contract LockedRevenueDistributionToken is ILockedRevenueDistributionToken, Reve
         if (fee_ > 0) {
             emit WithdrawalFeePaid(msg.sender, receiver_, owner_, fee_);
         }
+    }
+
+    /**
+     * @inheritdoc ILockedRevenueDistributionToken
+     * @dev Reentrancy modifier provided within the internal function call.
+     */
+    function withdraw(uint256 assets_, address receiver_, address owner_, uint256 maxShares_)
+        external
+        virtual
+        override
+        returns (uint256 shares_)
+    {
+        shares_ = withdraw(assets_, receiver_, owner_);
+        require(shares_ <= maxShares_, "LRDT:W:SLIPPAGE_PROTECTION");
     }
 
     /*░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░

--- a/src/interfaces/ILockedRevenueDistributionToken.sol
+++ b/src/interfaces/ILockedRevenueDistributionToken.sol
@@ -167,7 +167,7 @@ interface ILockedRevenueDistributionToken {
      * @notice Creates a new withdrawal request for future execution using the shares conversion at the point of
      * request. May only be executed after the unlock date.
      * @notice Transfers shares to the vault contract to reserve them, reducing share balance.
-     * @param  shares_ Number of shares to redeem upon unlock.
+     * @param  shares_ Amount of shares to redeem upon unlock.
      */
     function createWithdrawalRequest(uint256 shares_) external;
 
@@ -192,6 +192,48 @@ interface ILockedRevenueDistributionToken {
      */
     function updateVestingSchedule() external returns (uint256 issuanceRate_, uint256 freeAssets_);
 
+    /**
+     * @notice ERC5143 slippage-protected deposit method. The transaction will revert if the shares to be returned is
+     * less than minShares_.
+     * @param  assets_    Amount of assets to deposit.
+     * @param  receiver_  The receiver of the shares.
+     * @param  minShares_ Minimum amount of shares to be returned.
+     * @return shares_    Amount of shares returned to receiver_.
+     */
+    function deposit(uint256 assets_, address receiver_, uint256 minShares_) external returns (uint256 shares_);
+
+    /**
+     * @notice ERC5143 slippage-protected mint method. The transaction will revert if the assets to be deducted is
+     * greater than maxAssets_.
+     * @param  shares_    Amount of shares to mint.
+     * @param  receiver_  The receiver of the shares.
+     * @param  maxAssets_ Maximum amount of assets to be deducted.
+     * @return assets_    Amount of deducted when minting shares.
+     */
+    function mint(uint256 shares_, address receiver_, uint256 maxAssets_) external returns (uint256 assets_);
+
+    /**
+     * @notice ERC5143 slippage-protected redeem method. The transaction will revert if the assets to be returned is
+     * less than minAssets_.
+     * @param  shares_    Amount of shares to redeem.
+     * @param  receiver_  The receiver of the assets.
+     * @param  owner_     Owner of shares making redemption.
+     * @param  minAssets_ Minimum amount of assets to be returned.
+     * @return assets_    Amount of assets returned.
+     */
+    function redeem(uint256 shares_, address receiver_, address owner_, uint256 minAssets_) external returns (uint256 assets_);
+
+    /**
+     * @notice ERC5143 slippage-protected withdraw method. The transaction will revert if the shares to be deducted is
+     * greater than maxShares_.
+     * @param  assets_    Amount of assets to withdraw.
+     * @param  receiver_  The receiver of the assets.
+     * @param  owner_     Owner of shares making withdrawal.
+     * @param  maxShares_ Minimum amount of shares to be deducted.
+     * @return shares_    Amount of shares deducted.
+     */
+    function withdraw(uint256 assets_, address receiver_, address owner_, uint256 maxShares_) external returns (uint256 shares_);
+
     /*░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
     ░░░░                          View Functions                           ░░░░
     ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░*/
@@ -199,7 +241,7 @@ interface ILockedRevenueDistributionToken {
     /**
      * @notice Previews a redemption of shares for owner. Applies withdrawal fee if owner does not have an exemption.
      * @param  owner_  Owner of shares making redemption.
-     * @param  shares_ Number of shares to redeem.
+     * @param  shares_ Amount of shares to redeem.
      * @return assets_ Assets redeemed for shares for owner.
      * @param  fee_    The assets paid as fee.
      */
@@ -208,7 +250,7 @@ interface ILockedRevenueDistributionToken {
     /**
      * @notice Previews a withdrawal of assets for owner. Applies withdrawal fee if owner does not have an exemption.
      * @param  owner_  Owner of shares makeing withdrawal.
-     * @param  assets_ Number of assets to withdraw.
+     * @param  assets_ Amount of assets to withdraw.
      * @return shares_ Shares needed to be burned for owner.
      * @param  fee_    The assets paid as fee.
      */
@@ -220,7 +262,7 @@ interface ILockedRevenueDistributionToken {
      * @param  pos_     Index/position of the withdrawal request to be previewed.
      * @param  owner_   Owner of the withdrawal request.
      * @return request_ The WithdrawalRequest struct within storage.
-     * @return assets_  Number of assets returned to owner if withdrawn.
+     * @return assets_  Amount of assets returned to owner if withdrawn.
      * @return fee_     The assets paid as fee.
      */
     function previewWithdrawalRequest(uint256 pos_, address owner_)

--- a/test/LockedRevenueDistributionToken/ERC5143.t.sol
+++ b/test/LockedRevenueDistributionToken/ERC5143.t.sol
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity ^0.8.7;
+
+import "./LockedRevenueDistributionTokenBaseTest.t.sol";
+
+contract ERC5143Test is LockedRevenueDistributionTokenBaseTest {
+    function testCannotDepositOutsideSlippage() public {
+        _mintAndApprove(1 ether);
+        vm.expectRevert("LRDT:D:SLIPPAGE_PROTECTION");
+        vault.deposit(1 ether, alice, 2 ether);
+    }
+
+    function testDepositWithinSlippage() public {
+        _mintAndApprove(1 ether);
+        vault.deposit(1 ether, alice, 0.5 ether);
+    }
+
+    function testCannotMintOutsideSlippage() public {
+        _mintAndApprove(1 ether);
+        vm.expectRevert("LRDT:M:SLIPPAGE_PROTECTION");
+        vault.mint(1 ether, alice, 0.5 ether);
+    }
+
+    function testMintWithinSlippage() public {
+        _mintAndApprove(1 ether);
+        vault.mint(1 ether, alice, 2 ether);
+    }
+
+    function testRedeemOutsideSlippage() public {
+        _setUpDepositor(alice, 1 ether);
+        vm.expectRevert("LRDT:R:SLIPPAGE_PROTECTION");
+        vault.redeem(1 ether, alice, alice, 2 ether);
+    }
+
+    function testRedeemWithinSlippage() public {
+        _setUpDepositor(alice, 1 ether);
+        vault.redeem(1 ether, alice, alice, 0.5 ether);
+    }
+
+    function testWithdrawOutsideSlippage() public {
+        _setUpDepositor(alice, 1 ether);
+        vm.expectRevert("LRDT:W:SLIPPAGE_PROTECTION");
+        vault.withdraw(0.85 ether, alice, alice, 0.5 ether); // Account for instant withdrawal fee.
+    }
+
+    function testWithdrawWithinSlippage() public {
+        _setUpDepositor(alice, 1 ether);
+        vault.withdraw(0.85 ether, alice, alice, 2 ether); // Account for instant withdrawal fee.
+    }
+}

--- a/test/LockedRevenueDistributionToken/LockedRevenueDistributionTokenBaseTest.t.sol
+++ b/test/LockedRevenueDistributionToken/LockedRevenueDistributionTokenBaseTest.t.sol
@@ -40,6 +40,12 @@ abstract contract LockedRevenueDistributionTokenBaseTest is Test {
         assertEq(asset.balanceOf(depositor_), balanceBefore_);
     }
 
+    function _mintAndApprove(uint256 assets_) internal {
+        asset.mint(alice, assets_);
+        vm.startPrank(alice);
+        asset.approve(address(vault), assets_);
+    }
+
     function _addAndVestRewards(uint256 assets_) internal {
         asset.mint(address(vault), assets_);
         vault.updateVestingSchedule();


### PR DESCRIPTION
Adds ERC5143 slippage protection extension functions to the ERC4626 vault standard. This allows users to supply a minimum return amount to prevent front-running or previous calls to the vault from causing a lower amount of assets returned, or higher amount of shares deducted.

ref:
- https://eips.ethereum.org/EIPS/eip-5143