### PR TITLE
feat: fixes audit L1

### DIFF
--- a/src/interfaces/IGovernanceLockedRevenueDistributionToken.sol
+++ b/src/interfaces/IGovernanceLockedRevenueDistributionToken.sol
@@ -10,8 +10,8 @@ interface IGovernanceLockedRevenueDistributionToken {
      */
     struct Checkpoint {
         uint32 fromBlock;
-        uint112 votes;
-        uint112 shares;
+        uint96 votes;
+        uint96 shares;
     }
 
     /*░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
@@ -56,7 +56,7 @@ interface IGovernanceLockedRevenueDistributionToken {
     function userCheckpoints(address account_, uint256 pos_)
         external
         view
-        returns (uint32 fromBlock, uint112 votes, uint112 shares);
+        returns (uint32 fromBlock, uint96 votes, uint96 shares);
 
     /*░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
     ░░░░                         Public Functions                          ░░░░

--- a/test/GovernanceLockedRevenueDistributionToken/Compound.t.sol
+++ b/test/GovernanceLockedRevenueDistributionToken/Compound.t.sol
@@ -59,7 +59,7 @@ contract CompoundTest is GovernanceLockedRevenueDistributionTokenBaseTest {
 
         assertEq(vault.numCheckpoints(bob), 1);
 
-        (uint32 fromBlock_, uint112 votes_) = vault.checkpoints(bob, 0);
+        (uint32 fromBlock_, uint96 votes_) = vault.checkpoints(bob, 0);
         assertEq(fromBlock_, 1);
         assertEq(votes_, vault.convertToAssets(80));
         vm.stopPrank();

--- a/test/GovernanceLockedRevenueDistributionToken/GovernanceLockedRevenueDistributionTokenBaseTest.t.sol
+++ b/test/GovernanceLockedRevenueDistributionToken/GovernanceLockedRevenueDistributionTokenBaseTest.t.sol
@@ -39,7 +39,7 @@ abstract contract GovernanceLockedRevenueDistributionTokenBaseTest is Test {
             symbol,
             address(this),
             address(asset),
-            type(uint112).max,
+            type(uint96).max,
             10,
             26 weeks,
             0


### PR DESCRIPTION
Reimpmlement SafeCast for GLRDT. This was initially removed as each use would have been protected by the maximum supply, or unfeasible to hit in realistic scenarios (such as a length of an array exceeding a uint32).

To be on the safe side these have been re-implemented as it will also help those reading the contract to have confidence that the GLRDT contract has not been meaningfully changed from OZ's ERC20Votes.sol.