### PR TITLE
feat: fixes audit L2

### DIFF
--- a/src/LockedRevenueDistributionToken.sol
+++ b/src/LockedRevenueDistributionToken.sol
@@ -397,7 +397,7 @@ contract LockedRevenueDistributionToken is ILockedRevenueDistributionToken, Reve
         override
         returns (WithdrawalRequest memory request_, uint256 assets_, uint256 fee_)
     {
-        request_ = userWithdrawalRequests[msg.sender][pos_];
+        request_ = userWithdrawalRequests[owner_][pos_];
 
         if (withdrawalFeeExemptions[owner_] || request_.unlockedAt <= block.timestamp) {
             return (request_, request_.assets, 0);

--- a/test/LockedRevenueDistributionToken/StandardWithdrawal.t.sol
+++ b/test/LockedRevenueDistributionToken/StandardWithdrawal.t.sol
@@ -554,4 +554,21 @@ contract StandardWithdrawalTest is LockedRevenueDistributionTokenBaseTest {
         vault.executeWithdrawalRequest(0);
         vm.stopPrank();
     }
+
+    function testPreviewWithdrawalRequest() public {
+        // Exempt Bob from fees.
+        vault.setWithdrawalFeeExemption(bob, true);
+
+        // Create a deposit and withdrawal request for 2 ether for Bob. This should be fee exempt.
+        _setUpDepositor(bob, 2 ether);
+        vault.createWithdrawalRequest(vault.balanceOf(bob));
+
+        // Create a deposit and withdrawal request for 1 ether for Alice. This should not be fee exempt.
+        _setUpDepositor(alice, 1 ether);
+        vault.createWithdrawalRequest(vault.balanceOf(alice));
+
+        (, uint256 bobWithdrawAmount, uint256 bobFee) = vault.previewWithdrawalRequest(0, bob);
+        assertEq(bobWithdrawAmount, 2 ether);
+        assertEq(bobFee, 0);
+    }
 }


### PR DESCRIPTION
Fixes a bug in previewWithdrawalRequest wherein `msg.sender` was incorrectly used instead of owner. As a view function this would be broken when called using a public RPC. Fixed by replacing with owner_ param and adding test.