### PR TITLE
feat: fixes audit L5

### DIFF
--- a/lib/revenue-distribution-token/README.md
+++ b/lib/revenue-distribution-token/README.md
@@ -9,3 +9,7 @@ See diff using `make diff`.
 ### 1. Public `deposit`, `mint`
 
 To support reuse of the slippage-protected ERC5143 deposit and mint functions implemented in LRDT, the deposit and mint functions of RDT have been made public.
+
+### 2. Virtual `_mint`, `_burn`
+
+The lack of virtual modifier on the `_mint` and `_burn` function within RDT prevent these from being overridden. This was required within GLRDT to write checkpoints after minting new shares.

--- a/lib/revenue-distribution-token/contracts/RevenueDistributionToken.sol
+++ b/lib/revenue-distribution-token/contracts/RevenueDistributionToken.sol
@@ -147,7 +147,7 @@ contract RevenueDistributionToken is IRevenueDistributionToken, ERC20 {
     /*** Internal Functions ***/
     /**************************/
 
-    function _mint(uint256 shares_, uint256 assets_, address receiver_, address caller_) internal {
+    function _mint(uint256 shares_, uint256 assets_, address receiver_, address caller_) internal virtual {
         require(receiver_ != address(0), "RDT:M:ZERO_RECEIVER");
         require(shares_   != uint256(0), "RDT:M:ZERO_SHARES");
         require(assets_   != uint256(0), "RDT:M:ZERO_ASSETS");
@@ -164,7 +164,7 @@ contract RevenueDistributionToken is IRevenueDistributionToken, ERC20 {
         require(ERC20Helper.transferFrom(asset, caller_, address(this), assets_), "RDT:M:TRANSFER_FROM");
     }
 
-    function _burn(uint256 shares_, uint256 assets_, address receiver_, address owner_, address caller_) internal {
+    function _burn(uint256 shares_, uint256 assets_, address receiver_, address owner_, address caller_) internal virtual {
         require(receiver_ != address(0), "RDT:B:ZERO_RECEIVER");
         require(shares_   != uint256(0), "RDT:B:ZERO_SHARES");
         require(assets_   != uint256(0), "RDT:B:ZERO_ASSETS");

--- a/src/GovernanceLockedRevenueDistributionToken.sol
+++ b/src/GovernanceLockedRevenueDistributionToken.sol
@@ -136,7 +136,7 @@ contract GovernanceLockedRevenueDistributionToken is
         override
         returns (uint32 fromBlock_, uint96 votes_)
     {
-        Checkpoint storage checkpoint_ = userCheckpoints[account_][pos_];
+        Checkpoint memory checkpoint_ = userCheckpoints[account_][pos_];
         fromBlock_ = checkpoint_.fromBlock;
         votes_ = checkpoint_.assets;
     }
@@ -311,7 +311,7 @@ contract GovernanceLockedRevenueDistributionToken is
             return (0, 0);
         }
 
-        Checkpoint storage checkpoint_ = _unsafeAccess(ckpts, high_ - 1);
+        Checkpoint memory checkpoint_ = _unsafeAccess(ckpts, high_ - 1);
         return (checkpoint_.shares, checkpoint_.assets);
     }
 

--- a/src/GovernanceLockedRevenueDistributionToken.sol
+++ b/src/GovernanceLockedRevenueDistributionToken.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.7;
 
 import {ERC20} from "erc20/ERC20.sol";
+import {RevenueDistributionToken} from "revenue-distribution-token/RevenueDistributionToken.sol";
 import {LockedRevenueDistributionToken} from "./LockedRevenueDistributionToken.sol";
 import {IGovernanceLockedRevenueDistributionToken} from "./interfaces/IGovernanceLockedRevenueDistributionToken.sol";
 import {Math} from "./libraries/Math.sol";
@@ -114,6 +115,20 @@ contract GovernanceLockedRevenueDistributionToken is
     /**
      * @inheritdoc IGovernanceLockedRevenueDistributionToken
      */
+    function convertToAssets(uint256 shares_, uint256 blockNumber_)
+        public
+        view
+        virtual
+        override
+        returns (uint256 assets_)
+    {
+        (uint256 totalSupply_, uint256 totalAssets_) = _checkpointsLookup(totalSupplyCheckpoints, blockNumber_);
+        assets_ = totalSupply_ == 0 ? shares_ : (shares_ * totalAssets_) / totalSupply_;
+    }
+
+    /**
+     * @inheritdoc IGovernanceLockedRevenueDistributionToken
+     */
     function checkpoints(address account_, uint32 pos_)
         external
         view
@@ -123,7 +138,7 @@ contract GovernanceLockedRevenueDistributionToken is
     {
         Checkpoint storage checkpoint_ = userCheckpoints[account_][pos_];
         fromBlock_ = checkpoint_.fromBlock;
-        votes_ = checkpoint_.votes;
+        votes_ = checkpoint_.assets;
     }
 
     /**
@@ -142,7 +157,7 @@ contract GovernanceLockedRevenueDistributionToken is
             return 0;
         }
         uint256 shares_ = userCheckpoints[account_][pos_ - 1].shares;
-        votes_ = convertToAssets(shares_);
+        votes_ = convertToAssets(shares_, block.number);
     }
 
     /**
@@ -163,7 +178,8 @@ contract GovernanceLockedRevenueDistributionToken is
         returns (uint256 votes_)
     {
         require(blockNumber_ < block.number, "GLRDT:BLOCK_NOT_MINED");
-        votes_ = _checkpointsLookup(userCheckpoints[account_], blockNumber_, true);
+        (uint256 shares_,) = _checkpointsLookup(userCheckpoints[account_], blockNumber_);
+        votes_ = convertToAssets(shares_, blockNumber_);
     }
 
     /**
@@ -185,7 +201,7 @@ contract GovernanceLockedRevenueDistributionToken is
      */
     function getPastTotalSupply(uint256 blockNumber_) public view virtual override returns (uint256 totalSupply_) {
         require(blockNumber_ < block.number, "GLRDT:BLOCK_NOT_MINED");
-        totalSupply_ = _checkpointsLookup(totalSupplyCheckpoints, blockNumber_, false);
+        (totalSupply_,) = _checkpointsLookup(totalSupplyCheckpoints, blockNumber_);
     }
 
     /*░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
@@ -193,23 +209,27 @@ contract GovernanceLockedRevenueDistributionToken is
     ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░*/
 
     /**
-     * @inheritdoc ERC20
+     * @inheritdoc RevenueDistributionToken
      * @dev Snapshots the totalSupply after it has been increased.
      */
-    function _mint(address owner_, uint256 amount_) internal virtual override {
-        super._mint(owner_, amount_);
-        _moveVotingPower(address(0), delegates[owner_], amount_);
-        _writeCheckpoint(totalSupplyCheckpoints, _add, amount_);
+    function _mint(uint256 shares_, uint256 assets_, address receiver_, address caller_) internal virtual override {
+        super._mint(shares_, assets_, receiver_, caller_);
+        _moveVotingPower(address(0), delegates[receiver_], shares_);
+        _writeCheckpoint(totalSupplyCheckpoints, _add, shares_);
     }
 
     /**
-     * @inheritdoc ERC20
+     * @inheritdoc RevenueDistributionToken
      * @dev Snapshots the totalSupply after it has been decreased.
      */
-    function _burn(address owner_, uint256 amount_) internal virtual override {
-        super._burn(owner_, amount_);
-        _moveVotingPower(delegates[owner_], address(0), amount_);
-        _writeCheckpoint(totalSupplyCheckpoints, _subtract, amount_);
+    function _burn(uint256 shares_, uint256 assets_, address receiver_, address owner_, address caller_)
+        internal
+        virtual
+        override
+    {
+        super._burn(shares_, assets_, receiver_, owner_, caller_);
+        _moveVotingPower(delegates[owner_], address(0), shares_);
+        _writeCheckpoint(totalSupplyCheckpoints, _subtract, shares_);
     }
 
     /**
@@ -244,13 +264,13 @@ contract GovernanceLockedRevenueDistributionToken is
      * @notice Lookup a value in a list of (sorted) checkpoints.
      * @param  ckpts        List of checkpoints to find within.
      * @param  blockNumber_ Block number of latest checkpoint.
-     * @param  isVotes_     Return votes value when true, shares when false.
-     * @param  amount_      Amount of shares or votes at checkpoint.
+     * @param  shares_      Amount of shares at checkpoint.
+     * @param  assets_      Amount of assets at checkpoint.
      */
-    function _checkpointsLookup(Checkpoint[] storage ckpts, uint256 blockNumber_, bool isVotes_)
+    function _checkpointsLookup(Checkpoint[] storage ckpts, uint256 blockNumber_)
         private
         view
-        returns (uint256 amount_)
+        returns (uint96 shares_, uint96 assets_)
     {
         // We run a binary search to look for the earliest checkpoint taken after `blockNumber_`.
         //
@@ -287,8 +307,12 @@ contract GovernanceLockedRevenueDistributionToken is
             }
         }
 
-        return
-            high_ == 0 ? 0 : (isVotes_ ? _unsafeAccess(ckpts, high_ - 1).votes : _unsafeAccess(ckpts, high_ - 1).shares);
+        if (high_ == 0) {
+            return (0, 0);
+        }
+
+        Checkpoint storage checkpoint_ = _unsafeAccess(ckpts, high_ - 1);
+        return (checkpoint_.shares, checkpoint_.assets);
     }
 
     /**
@@ -332,13 +356,13 @@ contract GovernanceLockedRevenueDistributionToken is
 
         if (pos_ > 0 && oldCkpt_.fromBlock == block.number) {
             _unsafeAccess(ckpts, pos_ - 1).shares = _toUint96(newWeight_);
-            _unsafeAccess(ckpts, pos_ - 1).votes = _toUint96(convertToAssets(newWeight_));
+            _unsafeAccess(ckpts, pos_ - 1).assets = _toUint96(convertToAssets(newWeight_));
         } else {
             ckpts.push(
                 Checkpoint({
                     fromBlock: _toUint32(block.number),
                     shares: _toUint96(newWeight_),
-                    votes: _toUint96(convertToAssets(newWeight_))
+                    assets: _toUint96(convertToAssets(newWeight_))
                 })
             );
         }

--- a/src/interfaces/IGovernanceLockedRevenueDistributionToken.sol
+++ b/src/interfaces/IGovernanceLockedRevenueDistributionToken.sol
@@ -5,8 +5,8 @@ interface IGovernanceLockedRevenueDistributionToken {
     /**
      * @notice        Represents a voting checkpoin, packed into a single word.
      * @custom:member fromBlock Block number after which the checkpoint applies.
-     * @custom:member shares    Amount of shares held & delegated to calculate point-int-time votes.
-     * @custom:member assets    Number of votes available, representing the amount of assets for delegated shares.
+     * @custom:member shares    Amount of shares held & delegated to calculate point-in-time votes.
+     * @custom:member assets    Amount of assets held & delegated to calculate point-in-time votes.
      */
     struct Checkpoint {
         uint32 fromBlock;

--- a/src/interfaces/IGovernanceLockedRevenueDistributionToken.sol
+++ b/src/interfaces/IGovernanceLockedRevenueDistributionToken.sol
@@ -6,12 +6,12 @@ interface IGovernanceLockedRevenueDistributionToken {
      * @notice        Represents a voting checkpoin, packed into a single word.
      * @custom:member fromBlock Block number after which the checkpoint applies.
      * @custom:member shares    Amount of shares held & delegated to calculate point-int-time votes.
-     * @custom:member votes     Number of votes available, representing the amount of assets for delegated shares.
+     * @custom:member assets    Number of votes available, representing the amount of assets for delegated shares.
      */
     struct Checkpoint {
         uint32 fromBlock;
-        uint96 votes;
         uint96 shares;
+        uint96 assets;
     }
 
     /*░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
@@ -47,16 +47,16 @@ interface IGovernanceLockedRevenueDistributionToken {
     /**
      * @notice Get the `pos`-th checkpoint for `account`.
      * @dev    Unused in Compound governance specification, exposes underlying Checkpoint struct.
-     * @param  account_  Account that holds checkpoint.
-     * @param  pos_      Index/position of the checkpoint.
-     * @return fromBlock Block in which the checkpoint is valid from.
-     * @return votes     Total amount of underlying assets (votes) derived from shares.
-     * @return shares    Total amount of shares within the checkpoint.
+     * @param  account_   Account that holds checkpoint.
+     * @param  pos_       Index/position of the checkpoint.
+     * @return fromBlock  Block in which the checkpoint is valid from.
+     * @return shares     Total amount of shares within the checkpoint.
+     * @return assets     Total amount of underlying assets derived from shares at time of checkpoint.
      */
     function userCheckpoints(address account_, uint256 pos_)
         external
         view
-        returns (uint32 fromBlock, uint96 votes, uint96 shares);
+        returns (uint32 fromBlock, uint96 shares, uint96 assets);
 
     /*░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░
     ░░░░                         Public Functions                          ░░░░
@@ -86,6 +86,14 @@ interface IGovernanceLockedRevenueDistributionToken {
     ░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░*/
 
     /**
+     * @notice Historical conversion from shares to assets, used for calculating voting power on past blocks.
+     * @param  shares_      Amount of shares to conver to assets.
+     * @param  blockNumber_ Block to use for checkpoint lookup.
+     * @return assets_      Amount of assets held at block, representing voting power.
+     */
+    function convertToAssets(uint256 shares_, uint256 blockNumber_) external view returns (uint256 assets_);
+
+    /**
      * @notice Get the Compound-compatible `pos`-th checkpoint for `account`.
      * @dev    Maintains Compound `checkpoints` compatibility by returning votes as a uint96 and omitting shares.
      * @param  account_   Account that holds checkpoint.
@@ -103,7 +111,8 @@ interface IGovernanceLockedRevenueDistributionToken {
     /**
      * @notice Returns the current amount of votes that `account` has.
      * @dev    The delegated balance is denominated in the amount of shares delegated to an account, but voting power
-     * is measured in assets. A conversion is done using the delegated shares to get the current assets.
+     * is measured in assets. A conversion is done using the delegated shares to get the assets as of the latest
+     * checkpoint. This ensures that all stakers' shares are converted to assets at the same rate.
      * @param  account_ Address of account to get votes for.
      * @return votes_   Amount of voting power as the number of assets for delegated shares.
      */

--- a/test/GovernanceLockedRevenueDistributionToken/Metadata.t.sol
+++ b/test/GovernanceLockedRevenueDistributionToken/Metadata.t.sol
@@ -31,8 +31,8 @@ contract MetadataTest is GovernanceLockedRevenueDistributionTokenBaseTest {
 
             (uint32 fromBlock_, uint96 votes_) = vault.checkpoints(alice, uint32(i_));
             assertEq(fromBlock_, block.number);
-            assertEq(votes_, 1 ether * i_); // Checkpoint is one value behind current.
-            assertEq(vault.getCurrentVotes(alice), 1 ether * (i_ + 1)); // Current.
+            assertEq(votes_, 1 ether * (i_ + 1));
+            assertEq(vault.getCurrentVotes(alice), 1 ether * (i_ + 1));
 
             vm.roll(block.number + 1);
         }

--- a/test/GovernanceLockedRevenueDistributionToken/Rewards.t.sol
+++ b/test/GovernanceLockedRevenueDistributionToken/Rewards.t.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity ^0.8.7;
+
+import "./GovernanceLockedRevenueDistributionTokenBaseTest.t.sol";
+
+contract RewardsTest is GovernanceLockedRevenueDistributionTokenBaseTest {
+  function testRewardsAccountedFor() public {
+    // Setup Alice as a depositor before rewards are distributed. 
+    mint(alice, mintAmount);
+    vm.prank(alice);
+    vault.delegate(alice);
+    assertEq(vault.getVotes(alice), vault.balanceOfAssets(alice));
+
+    // Distribute 0.1 ether worth of rewards to Alice.
+    asset.mint(address(vault), 0.1 ether);
+    vault.updateVestingSchedule();
+    vm.warp(block.timestamp + 2 weeks);
+    assertEq(vault.balanceOfAssets(alice), 1.1 ether - 1); // Rounds down.
+
+    // Alice's voting power is currently unchanged, this is expected because Alice remains to be the only voter so he
+    // share of the total voting power remains the same.
+    assertEq(vault.getVotes(alice), mintAmount);
+    assertFalse(vault.getVotes(alice) == vault.balanceOfAssets(alice));
+
+    // Bob now deposits 1 ether at the current rate.
+    mint(bob, mintAmount);
+    vm.prank(bob);
+    vault.delegate(bob);
+    assertEq(vault.getVotes(bob), vault.balanceOfAssets(bob));
+
+    // Alice's voting power will now have updated to include her rewards at the time of Bob's deposit, meaning that
+    // both Alice and Bob have accurate voting power to each other when the block was mined.
+    vm.roll(block.number + 1);
+    assertEq(vault.getVotes(alice), vault.balanceOfAssets(alice));
+    assertEq(vault.getPastVotes(alice, block.number - 1), vault.balanceOfAssets(alice));
+    assertEq(vault.getVotes(bob), vault.balanceOfAssets(bob));
+    assertEq(vault.getPastVotes(bob, block.number - 1), vault.balanceOfAssets(bob));
+  }
+}

--- a/test/GovernanceLockedRevenueDistributionToken/Rewards.t.sol
+++ b/test/GovernanceLockedRevenueDistributionToken/Rewards.t.sol
@@ -17,7 +17,7 @@ contract RewardsTest is GovernanceLockedRevenueDistributionTokenBaseTest {
     vm.warp(block.timestamp + 2 weeks);
     assertEq(vault.balanceOfAssets(alice), 1.1 ether - 1); // Rounds down.
 
-    // Alice's voting power is currently unchanged, this is expected because Alice remains to be the only voter so he
+    // Alice's voting power is currently unchanged, this is expected because Alice remains to be the only voter so her
     // share of the total voting power remains the same.
     assertEq(vault.getVotes(alice), mintAmount);
     assertFalse(vault.getVotes(alice) == vault.balanceOfAssets(alice));


### PR DESCRIPTION
One thing lead to another and this commit implements a much more comprehensive fix for the issue raised.

There were a number of linked issues in the current implementation:

- Due to overriding the ERC20._mint function freeAssets was not yet set at the time convertToAssets was called, returning the asset amount prior to the freeAssets update.
- Users would need to checkpoint their balance again in order for their rewards to be reflected.

That last point was the main motivator for this change. Lets say that Alice deposits 1 ether at a rate of 1.1, giving her voting power of 1.1 ether. After 100 blocks of rewards the rate then becomes 1.2 and Bob makes a deposit. At block 100 Bob would have a usable checkpoint with a voting power of 1.2 ether and Alice's voting power would remain at 1.1 ether, forcing Alice to re-checkpoint in order to capture the assets earned.

We had attempted to avoid this in the original design but due to a misunderstanding of how Compound governor read the voting checkpoints this resulted in incorrect handling.

To fix this we now take a different approach and expose a convertToAssets function that accepts a blockNumber parameter. This uses the totalSupplyCheckpoints that are updated on each deposit and burn to convert the user's share balance within the checkpoint to assets at a specific block. Note here that `checkpoint.assets` is written for both totalSupplyCheckpoints and userCheckpoints, but is not used to calculate voting power on the userCheckpoint.

The key difference instead is that the `checkpoint.shares` is passed to the new convertToAssets function so that all stakers' voting power is consistent to the block. Summarised:

1. Upon each mint and burn the total supply of shares and assets is recorded.
2. The share balance for each user is checkpointed.
3. When calculating voting power the user's share balance is retrieved and conveted to assets using the total supply checkpoint at that block.

Therefore Alice would not need to re-checkpoint her rewards earned at block 100 as this is recalculated due to the totalSupplyCheckpoint created thanks to Bob's deposit.