### PR TITLE
feat: fixes audit L7

### DIFF
--- a/src/LockedRevenueDistributionToken.sol
+++ b/src/LockedRevenueDistributionToken.sol
@@ -224,6 +224,8 @@ contract LockedRevenueDistributionToken is ILockedRevenueDistributionToken, Reve
         issuanceRate_ =
             (issuanceRate = ((ERC20(asset).balanceOf(address(this)) - freeAssets_) * precision) / vestingTime_);
 
+        require(issuanceRate_ > 0, "LRDT:UVS:ZERO_ISSUANCE_RATE");
+
         // Update timestamp and period finish.
         vestingPeriodFinish = (lastUpdated = block.timestamp) + vestingTime_;
 

--- a/test/LockedRevenueDistributionToken/UpdateVestingSchedule.t.sol
+++ b/test/LockedRevenueDistributionToken/UpdateVestingSchedule.t.sol
@@ -4,6 +4,17 @@ pragma solidity ^0.8.7;
 import "./LockedRevenueDistributionTokenBaseTest.t.sol";
 
 contract UpdateVestingScheduleTest is LockedRevenueDistributionTokenBaseTest {
+    function testCannotUpdateVestingScheduleZeroSupply() public {
+        vm.expectRevert("LRDT:UVS:ZERO_SUPPLY");
+        vault.updateVestingSchedule();
+    }
+
+    function testCannotUpdateVestingScheduleZeroIssuanceRate() public {
+        _setUpDepositor(alice, 1 ether);
+        vm.expectRevert("LRDT:UVS:ZERO_ISSUANCE_RATE");
+        vault.updateVestingSchedule();
+    }
+
     function testUpdateVestingScheduleAsNonOwner() public {
         vm.startPrank(alice);
         asset.mint(alice, 1 ether);
@@ -53,10 +64,5 @@ contract UpdateVestingScheduleTest is LockedRevenueDistributionTokenBaseTest {
         vm.warp(block.timestamp + 2 weeks - 8 hours); // Warp to Monday 4am
         vault.updateVestingSchedule();
         assertEq(vault.vestingPeriodFinish(), block.timestamp + 2 weeks + 8 hours); // Expect Monday 12pm
-    }
-
-    function testCannotUpdateVestingScheduleZeroSupply() public {
-        vm.expectRevert("LRDT:UVS:ZERO_SUPPLY");
-        vault.updateVestingSchedule();
     }
 }


### PR DESCRIPTION
Require check added to ensure that updateVestingSchedule cannot be called when the upcoming issuance rate is calculated to be zero. Without this check it is possible to 'lock in' a vesting period with zero issuance.